### PR TITLE
fix: don't trim replies that are appended to the original HTML

### DIFF
--- a/src/fixBrokenHtml.ts
+++ b/src/fixBrokenHtml.ts
@@ -24,10 +24,12 @@ function fixBrokenHead(inputHtml: string): string {
 
 			encounteredTags.add(name);
 
-			const headTag = encounteredTags.has('head');
 			const htmlTag = encounteredTags.has('html');
+			const headTag = encounteredTags.has('head');
+			const blockquoteTag = encounteredTags.has('blockquote');
 
-			if (!htmlTag && headTag) {
+			// If there's a blockquote before the head tag, this is likely a quoted message
+			if (!htmlTag && headTag && !blockquoteTag) {
 				isBroken = true;
 				parserDetect.reset(); // abort parsing
 			} else if (htmlTag) {

--- a/src/tests/prepareMessage/trimmed-reply-bug.input.html
+++ b/src/tests/prepareMessage/trimmed-reply-bug.input.html
@@ -1,0 +1,99 @@
+<p>Hi Mette,</p>
+<p>I have attached our contracts for the USD 500.000 investment regarding BoostVC. Please let me know if thats what is needed.</p>
+<p>Kind Regards</p>
+<p>Henrique </p>
+<p>--<br>I use <a href="https://www.yourtempo.co">Tempo</a> to improve my focus</p>
+<br /><br /><blockquote class="gmail_quote" style="margin:0">
+On Tue, Apr 13 2021 at 10:37 AM (GMT+2), mette.randers@dk.gt.com wrote:
+<br /><br />
+<meta content="text/html; charset=us-ascii"><div xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<meta name="Generator" content="Microsoft Word 15 (filtered medium)">
+<style>
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:#954F72;
+	text-decoration:underline;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Arial",sans-serif;
+	color:windowtext;
+	font-weight:normal;
+	font-style:normal;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:3.0cm 2.0cm 3.0cm 2.0cm;}
+div.WordSection1
+	{page:WordSection1;}
+</style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext="edit" spidmax="1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext="edit">
+<o:idmap v:ext="edit" data="1" />
+</o:shapelayout></xml><![endif]-->
+</head>
+<div lang="DA" link="#0563C1" vlink="#954F72" style="word-wrap:break-word">
+<div class="WordSection1">
+<p class="MsoNormal"><span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif">Hi Henrique.<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif"><o:p>&nbsp;</o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif">I hope you&#8217;re doing well.<o:p></o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif"><o:p>&nbsp;</o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif">Reviewing the bookkeeping for the first quarter in 2021, could you please send me the agreement regarding enclosed, USD 500.000 received on 20. Jan?<o:p></o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif"><o:p>&nbsp;</o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif">Thanks in advance.</span><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif"><o:p></o:p></span></p>
+<p class="MsoNormal"><span lang="EN-US" style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif"><o:p>&nbsp;</o:p></span></p>
+<div>
+<p class="MsoNormal" style="mso-margin-top-alt:auto;mso-margin-bottom-alt:auto"><span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">Med venlig hilsen</span><span style="font-size:9.0pt;mso-fareast-language:DA"><br>
+<br>
+</span><b><span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#4F2D7F;mso-fareast-language:DA">Mette Randers</span></b><span style="mso-fareast-language:DA"><br>
+</span><span style="font-size:10.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">Regnskabskonsulent</span><span style="mso-fareast-language:DA"><o:p></o:p></span></p>
+<p class="MsoNormal"><b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">D</span></b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">
+ +4535275268</span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+</span><b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">T</span></b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA"> +4533110220</span><span lang="EN-US" style="font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">&nbsp;
+</span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+</span><b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;mso-fareast-language:DA">M</span></b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;mso-fareast-language:DA"> +4526881988<b>
+</b></span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+</span><b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;mso-fareast-language:DA">E&nbsp;</span></b><span style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA"><a href="mailto:Mette.Randers@dk.gt.com"><span lang="EN-US" style="color:blue">Mette.Randers@dk.gt.com</span></a></span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+<br>
+</span><b><span lang="EN-US" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:black;mso-fareast-language:DA">www.grantthornton.dk</span></b><span lang="EN-US" style="mso-fareast-language:DA"> |&nbsp;</span><a href="https://www.linkedin.com/company/grant-thornton-denmark"><span style="color:blue;mso-fareast-language:DA;text-decoration:none"><img border="0" width="14" height="14" style="width:.15in;height:.15in" id="_x0000_i1027" src="cid:image001.png@01D73051.10303D00"></span></a><span lang="EN-US" style="mso-fareast-language:DA">&nbsp;|&nbsp;</span><a href="https://teams.microsoft.com/l/chat/0/0?users=Mette.Randers@dk.gt.com&amp;topicname=Chat"><span style="color:blue;mso-fareast-language:DA;text-decoration:none"><img border="0" width="17" height="17" style="width:.175in;height:.175in" id="_x0000_i1026" src="cid:image002.png@01D73051.10303D00"></span></a><b><span style="font-size:9.0pt;mso-fareast-language:DA"><a href="https://teams.microsoft.com/l/chat/0/0?users=Mette.Randers@dk.gt.com&amp;topicname=Chat"><span lang="EN-US" style="color:#3399FF">&nbsp;Chat
+ with me on Teams!</span></a></span></b><span lang="EN-US" style="mso-fareast-language:DA"><br>
+<span style="color:#4F2D7F">__________________________________________</span><br>
+<br>
+</span><span lang="EN-US" style="font-size:8.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#221E1F;mso-fareast-language:DA">Grant Thornton<br>
+Stockholmsgade 45<br>
+2100 København&nbsp;Ø </span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+</span><span style="mso-fareast-language:DA"><img border="0" width="255" height="100" style="width:2.6583in;height:1.0416in" id="_x0000_i1025" src="cid:image003.png@01D73051.10303D00"></span><span lang="EN-US" style="mso-fareast-language:DA"><br>
+</span><span lang="EN-US" style="font-size:8.0pt;font-family:&quot;Arial&quot;,sans-serif;mso-fareast-language:DA">Grant Thornton International Ltd (GTIL) is a company limited by guarantee incorporated in England and Wales with registered number 05523714 (registered
+ office: Grant Thornton House, 20 Fenchurch Street, Level 25 London EC3M 3BY, UK). GTIL and the member firms are not a worldwide partnership. Services are delivered by the member firms. GTIL and its member firms are not agents of, and do not obligate, one another
+ and are not liable for one another&#8217;s acts or omissions. Please see www.GrantThornton.global for further details.<br>
+<br>
+The name &#8220;Grant Thornton&#8221;, the Grant Thornton logo, including the Mobius symbol/device, and &#8220;Instinct for Growth&#8221; are trademarks of GTIL. All copyright is owned by GTIL, including the copyright in the Grant Thornton logo; all rights are reserved.<br>
+<br>
+This email (and any attachments) is confidential and may also be legally privileged. Anything in this email (and any attachments) which does not relate to official business of GTIL is neither given nor endorsed by GTIL. If you have received this email in error,
+ please notify the sender immediately, delete it from your system and destroy any copies of it (and any attachments).</span><span lang="EN-US" style="mso-fareast-language:DA">
+<o:p></o:p></span></p>
+<p class="MsoNormal" style="mso-margin-top-alt:auto;mso-margin-bottom-alt:auto"><span lang="EN-US" style="mso-fareast-language:DA">&nbsp;</span><span lang="EN-US"><o:p></o:p></span></p>
+</div>
+</div>
+</div>
+</div>
+</meta>
+</blockquote>

--- a/src/tests/prepareMessage/trimmed-reply-bug.output-complete.html
+++ b/src/tests/prepareMessage/trimmed-reply-bug.output-complete.html
@@ -1,0 +1,257 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      .customStyle {
+        background: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Hi Mette,</p>
+    <p>
+      I have attached our contracts for the USD 500.000 investment regarding BoostVC. Please let me know if thats what
+      is needed.
+    </p>
+    <p>Kind Regards</p>
+    <p>Henrique</p>
+    <p>--<br />I use <a href="https://www.yourtempo.co">Tempo</a> to improve my focus</p>
+    <br /><br />
+    <blockquote class="gmail_quote" style="margin:0">
+      On Tue, Apr 13 2021 at 10:37 AM (GMT+2),
+      <a href="mailto:mette.randers@dk.gt.com" target="_blank" rel="noopener noreferrer">mette.randers@dk.gt.com</a>
+      wrote: <br /><br />
+      <meta content="text/html; charset=us-ascii" />
+      <div
+        xmlns:v="urn:schemas-microsoft-com:vml"
+        xmlns:o="urn:schemas-microsoft-com:office:office"
+        xmlns:w="urn:schemas-microsoft-com:office:word"
+        xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
+        xmlns="http://www.w3.org/TR/REC-html40"
+      >
+        <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+        <meta name="Generator" content="Microsoft Word 15 (filtered medium)" />
+        <style>
+          /* Font Definitions */
+          @font-face {
+            font-family: "Cambria Math";
+            panose-1: 2 4 5 3 5 4 6 3 2 4;
+          }
+          @font-face {
+            font-family: Calibri;
+            panose-1: 2 15 5 2 2 2 4 3 2 4;
+          }
+          /* Style Definitions */
+          p.MsoNormal,
+          li.MsoNormal,
+          div.MsoNormal {
+            margin: 0cm;
+            font-size: 11pt;
+            font-family: "Calibri", sans-serif;
+            mso-fareast-language: EN-US;
+          }
+          a:visited,
+          span.MsoHyperlinkFollowed {
+            mso-style-priority: 99;
+            color: #954f72;
+            text-decoration: underline;
+          }
+          span.EmailStyle17 {
+            mso-style-type: personal-compose;
+            font-family: "Arial", sans-serif;
+            color: windowtext;
+            font-weight: normal;
+            font-style: normal;
+          }
+          .MsoChpDefault {
+            mso-style-type: export-only;
+            font-family: "Calibri", sans-serif;
+            mso-fareast-language: EN-US;
+          }
+          @page WordSection1 {
+            size: 612pt 792pt;
+            margin: 3cm 2cm 3cm 2cm;
+          }
+          div.WordSection1 {
+            page: WordSection1;
+          }
+        </style>
+
+        <div lang="DA" link="#0563C1" vlink="#954F72" style="word-wrap:break-word">
+          <div class="WordSection1">
+            <p class="MsoNormal">
+              <span style='font-size:10.0pt;font-family:"Arial",sans-serif'>Hi Henrique.<o:p></o:p></span>
+            </p>
+            <p class="MsoNormal">
+              <span style='font-size:10.0pt;font-family:"Arial",sans-serif'><o:p>&#xA0;</o:p></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'
+                >I hope you&#x2019;re doing well.<o:p></o:p
+              ></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'><o:p>&#xA0;</o:p></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'
+                >Reviewing the bookkeeping for the first quarter in 2021, could you please send me the agreement
+                regarding enclosed, USD 500.000 received on 20. Jan?<o:p></o:p
+              ></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'><o:p>&#xA0;</o:p></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'>Thanks in advance.</span
+              ><span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'><o:p></o:p></span>
+            </p>
+            <p class="MsoNormal">
+              <span lang="EN-US" style='font-size:10.0pt;font-family:"Arial",sans-serif'><o:p>&#xA0;</o:p></span>
+            </p>
+            <div>
+              <p class="MsoNormal" style="mso-margin-top-alt:auto;mso-margin-bottom-alt:auto">
+                <span style='font-size:10.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                  >Med venlig hilsen</span
+                ><span style="font-size:9.0pt;mso-fareast-language:DA"
+                  ><br />
+                  <br /> </span
+                ><b
+                  ><span style='font-size:10.0pt;font-family:"Arial",sans-serif;color:#4F2D7F;mso-fareast-language:DA'
+                    >Mette Randers</span
+                  ></b
+                ><span style="mso-fareast-language:DA"><br /> </span
+                ><span style='font-size:10.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                  >Regnskabskonsulent</span
+                ><span style="mso-fareast-language:DA"><o:p></o:p></span>
+              </p>
+              <p class="MsoNormal">
+                <b
+                  ><span
+                    lang="EN-US"
+                    style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                    >D</span
+                  ></b
+                ><span
+                  lang="EN-US"
+                  style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                >
+                  <a href="tel:+4535275268" target="_blank" rel="noopener noreferrer">+4535275268</a></span
+                ><span lang="EN-US" style="mso-fareast-language:DA"><br /> </span
+                ><b
+                  ><span
+                    lang="EN-US"
+                    style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                    >T</span
+                  ></b
+                ><span
+                  lang="EN-US"
+                  style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                >
+                  <a href="tel:+4533110220" target="_blank" rel="noopener noreferrer">+4533110220</a></span
+                ><span lang="EN-US" style='font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                  >&#xA0; </span
+                ><span lang="EN-US" style="mso-fareast-language:DA"><br /> </span
+                ><b
+                  ><span lang="EN-US" style='font-size:9.0pt;font-family:"Arial",sans-serif;mso-fareast-language:DA'
+                    >M</span
+                  ></b
+                ><span lang="EN-US" style='font-size:9.0pt;font-family:"Arial",sans-serif;mso-fareast-language:DA'>
+                  <a href="tel:+4526881988" target="_blank" rel="noopener noreferrer">+4526881988</a><b> </b></span
+                ><span lang="EN-US" style="mso-fareast-language:DA"><br /> </span
+                ><b
+                  ><span lang="EN-US" style='font-size:9.0pt;font-family:"Arial",sans-serif;mso-fareast-language:DA'
+                    >E&#xA0;</span
+                  ></b
+                ><span style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                  ><a href="mailto:Mette.Randers@dk.gt.com"
+                    ><span lang="EN-US" style="color:blue">Mette.Randers@dk.gt.com</span></a
+                  ></span
+                ><span lang="EN-US" style="mso-fareast-language:DA"
+                  ><br />
+                  <br /> </span
+                ><b
+                  ><span
+                    lang="EN-US"
+                    style='font-size:9.0pt;font-family:"Arial",sans-serif;color:black;mso-fareast-language:DA'
+                    ><a href="http://www.grantthornton.dk" target="_blank" rel="noopener noreferrer"
+                      >www.grantthornton.dk</a
+                    ></span
+                  ></b
+                ><span lang="EN-US" style="mso-fareast-language:DA"> |&#xA0;</span
+                ><a href="https://www.linkedin.com/company/grant-thornton-denmark"
+                  ><span style="color:blue;mso-fareast-language:DA;text-decoration:none"
+                    ><img
+                      border="0"
+                      width="14"
+                      height="14"
+                      style="width:.15in;height:.15in"
+                      id="_x0000_i1027"
+                      src="cid:image001.png@01D73051.10303D00"/></span></a
+                ><span lang="EN-US" style="mso-fareast-language:DA">&#xA0;|&#xA0;</span
+                ><a href="https://teams.microsoft.com/l/chat/0/0?users=Mette.Randers@dk.gt.com&amp;topicname=Chat"
+                  ><span style="color:blue;mso-fareast-language:DA;text-decoration:none"
+                    ><img
+                      border="0"
+                      width="17"
+                      height="17"
+                      style="width:.175in;height:.175in"
+                      id="_x0000_i1026"
+                      src="cid:image002.png@01D73051.10303D00"/></span></a
+                ><b
+                  ><span style="font-size:9.0pt;mso-fareast-language:DA"
+                    ><a href="https://teams.microsoft.com/l/chat/0/0?users=Mette.Randers@dk.gt.com&amp;topicname=Chat"
+                      ><span lang="EN-US" style="color:#3399FF">&#xA0;Chat with me on Teams!</span></a
+                    ></span
+                  ></b
+                ><span lang="EN-US" style="mso-fareast-language:DA"
+                  ><br />
+                  <span style="color:#4F2D7F">__________________________________________</span><br />
+                  <br /> </span
+                ><span
+                  lang="EN-US"
+                  style='font-size:8.0pt;font-family:"Arial",sans-serif;color:#221E1F;mso-fareast-language:DA'
+                  >Grant Thornton<br />
+                  Stockholmsgade 45<br />
+                  2100 K&#xF8;benhavn&#xA0;&#xD8; </span
+                ><span lang="EN-US" style="mso-fareast-language:DA"><br /> </span
+                ><span style="mso-fareast-language:DA"
+                  ><img
+                    border="0"
+                    width="255"
+                    height="100"
+                    style="width:2.6583in;height:1.0416in"
+                    id="_x0000_i1025"
+                    src="cid:image003.png@01D73051.10303D00"/></span
+                ><span lang="EN-US" style="mso-fareast-language:DA"><br /> </span
+                ><span lang="EN-US" style='font-size:8.0pt;font-family:"Arial",sans-serif;mso-fareast-language:DA'
+                  >Grant Thornton International Ltd (GTIL) is a company limited by guarantee incorporated in England and
+                  Wales with registered number 05523714 (registered office: Grant Thornton House, 20 Fenchurch Street,
+                  Level 25 London EC3M 3BY, UK). GTIL and the member firms are not a worldwide partnership. Services are
+                  delivered by the member firms. GTIL and its member firms are not agents of, and do not obligate, one
+                  another and are not liable for one another&#x2019;s acts or omissions. Please see
+                  <a href="http://www.GrantThornton.global" target="_blank" rel="noopener noreferrer"
+                    >www.GrantThornton.global</a
+                  >
+                  for further details.<br />
+                  <br />
+                  The name &#x201C;Grant Thornton&#x201D;, the Grant Thornton logo, including the Mobius symbol/device,
+                  and &#x201C;Instinct for Growth&#x201D; are trademarks of GTIL. All copyright is owned by GTIL,
+                  including the copyright in the Grant Thornton logo; all rights are reserved.<br />
+                  <br />
+                  This email (and any attachments) is confidential and may also be legally privileged. Anything in this
+                  email (and any attachments) which does not relate to official business of GTIL is neither given nor
+                  endorsed by GTIL. If you have received this email in error, please notify the sender immediately,
+                  delete it from your system and destroy any copies of it (and any attachments).</span
+                ><span lang="EN-US" style="mso-fareast-language:DA"> <o:p></o:p></span>
+              </p>
+              <p class="MsoNormal" style="mso-margin-top-alt:auto;mso-margin-bottom-alt:auto">
+                <span lang="EN-US" style="mso-fareast-language:DA">&#xA0;</span><span lang="EN-US"><o:p></o:p></span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </blockquote>
+  </body>
+</html>

--- a/src/tests/prepareMessage/trimmed-reply-bug.output-message.html
+++ b/src/tests/prepareMessage/trimmed-reply-bug.output-message.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      .customStyle {
+        background: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Hi Mette,</p>
+    <p>
+      I have attached our contracts for the USD 500.000 investment regarding BoostVC. Please let me know if thats what
+      is needed.
+    </p>
+    <p>Kind Regards</p>
+    <p>Henrique</p>
+    <p>--<br />I use <a href="https://www.yourtempo.co">Tempo</a> to improve my focus</p>
+  </body>
+</html>


### PR DESCRIPTION
The last change we did to fix broken `<head>` (#31) now trims the reply that Tempo prepends when replying to a message.
Tempo just prepend the reply HTML to the original HTML document. See failing test as an example.
Also, the test `dirty-head` is incorrect, since it removes the reply at the beginning of the file too 

```
Xxxxxxxxxx Xxxxxxxx Xáxxxx - Xxxxxx Xxxóxxxx Xx xãx xxxxxxxx xxxxxxxxxx xxxxxxxxxxxx xxxx x-xxxx, xxxxxx xx xxxxãx
	xxxxxx. Xxxxxxxx Xáxxxx Xxxxx-xxxxx, 00 xx Xxxçx xx 0000 X
```