### PR TITLE
fix: don't replace the links in GitHub's emoji components

### DIFF
--- a/src/linkify.ts
+++ b/src/linkify.ts
@@ -1,5 +1,7 @@
 import Autolinker from 'autolinker';
 
+const GH_EMOJI_URL = 'github.githubassets.com/images/icons/emoji';
+
 /**
  * Wrap text links in anchor tags
  */
@@ -30,6 +32,11 @@ function linkify(inputHtml: string): string {
 				const previousChar = inputHtml.charAt(match.getOffset() - 1);
 				if (previousChar === '/') {
 					return false; // don't autolink this match
+				}
+
+				// Don't autolink URLs for GitHub's Emoji
+				if (match.getAnchorHref().includes(GH_EMOJI_URL)) {
+					return false;
 				}
 
 				// Ignore URLs in head

--- a/src/tests/prepareMessage/github-emoji.input.html
+++ b/src/tests/prepareMessage/github-emoji.input.html
@@ -1,0 +1,7 @@
+<p></p>
+
+<p><b>@alexandersandberg</b> approved this pull request.</p>
+
+<p>Nice job! <g-emoji class="g-emoji" alias="heart_eyes" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f60d.png">😍</g-emoji> Really nice to have this on mobile as well!</p>
+
+<p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">&mdash;<br />You are receiving this because you authored the thread.<br />Reply to this email directly, <a href="https://github.com/">view it on GitHub</a>, or <a href="https://github.com/">unsubscribe</a>.<img src="https://github.com/notifications/beacon/AAEEHPHVBB3HVJZPBPV2AUTUDCEZDA5CNFSM5EOKBXU2YY3PNVWWK3TUL52HS4DFWFIHK3DMKJSXC5LFON2FEZLWNFSXPKTDN5WW2ZLOORPWSZGOFVEVKOA.gif" height="1" width="1" alt="" /></p>

--- a/src/tests/prepareMessage/github-emoji.output-complete.html
+++ b/src/tests/prepareMessage/github-emoji.output-complete.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      .customStyle {
+        background: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p></p>
+
+    <p><b>@alexandersandberg</b> approved this pull request.</p>
+
+    <p>
+      Nice job!
+      <g-emoji
+        class="g-emoji"
+        alias="heart_eyes"
+        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f60d.png"
+        >&#x1F60D;</g-emoji
+      >
+      Really nice to have this on mobile as well!
+    </p>
+
+    <p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">
+      &#x2014;<br />You are receiving this because you authored the thread.<br />Reply to this email directly,
+      <a href="https://github.com/" title="https://github.com/">view it on GitHub</a>, or
+      <a href="https://github.com/" title="https://github.com/">unsubscribe</a>.
+    </p>
+  </body>
+</html>

--- a/src/tests/prepareMessage/github-emoji.output-message.html
+++ b/src/tests/prepareMessage/github-emoji.output-message.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <style>
+      .customStyle {
+        background: red;
+      }
+    </style>
+  </head>
+  <body>
+    <p></p>
+
+    <p><b>@alexandersandberg</b> approved this pull request.</p>
+
+    <p>
+      Nice job!
+      <g-emoji
+        class="g-emoji"
+        alias="heart_eyes"
+        fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f60d.png"
+        >&#x1F60D;</g-emoji
+      >
+      Really nice to have this on mobile as well!
+    </p>
+
+    <p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">
+      &#x2014;<br />You are receiving this because you authored the thread.<br />Reply to this email directly,
+      <a href="https://github.com/" title="https://github.com/">view it on GitHub</a>, or
+      <a href="https://github.com/" title="https://github.com/">unsubscribe</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a fix to ensure that links inside of GitHub's `g-emoji` components aren't replaced. Autolinker has issues with recognizing it as an HTML tag and replaces the link inside of its `fallback-src` attribute with an anchor tag which breaks the processing afterwards.